### PR TITLE
fix(delete): Remove Deletion Polling

### DIFF
--- a/src/lambda_functions/lex_v2_cfn_cr/lambda_function.py
+++ b/src/lambda_functions/lex_v2_cfn_cr/lambda_function.py
@@ -104,6 +104,7 @@ def create_resource(event, _):
 
     raise RuntimeError(f"Invalid resource type: {resource_type}")
 
+
 @HELPER.delete
 def delete_resource(event, _):
     """Delete Resource"""
@@ -157,7 +158,9 @@ def delete_resource(event, _):
         if bot_alias_id and bot_id:
             try:
                 LEX_CUSTOM_RESOURCE.delete_bot_alias(bot_id=bot_id, bot_alias_id=bot_alias_id)
-                LEX_CUSTOM_RESOURCE.wait_for_delete_bot_alias(bot_id=bot_id, bot_alias_id=bot_alias_id)
+                LEX_CUSTOM_RESOURCE.wait_for_delete_bot_alias(
+                    bot_id=bot_id, bot_alias_id=bot_alias_id
+                )
             except CLIENT.exceptions.PreconditionFailedException:
                 LOGGER.info(
                     "Bot alias does not exist - bot_id: %s - bot_alias_id: %s",

--- a/src/lambda_functions/lex_v2_cfn_cr/lambda_function.py
+++ b/src/lambda_functions/lex_v2_cfn_cr/lambda_function.py
@@ -104,33 +104,6 @@ def create_resource(event, _):
 
     raise RuntimeError(f"Invalid resource type: {resource_type}")
 
-
-@HELPER.poll_delete
-def poll_delete(event, _):
-    """Poll Delete"""
-    resource_type = event["ResourceType"]
-    helper_data = event["CrHelperData"]
-
-    if resource_type == "Custom::LexBot":
-        bot_id = helper_data.get("botId")
-        if bot_id:
-            LEX_CUSTOM_RESOURCE.wait_for_delete_bot(bot_id=bot_id)
-
-        return True
-
-    if resource_type == "Custom::LexBotVersion":
-        return True
-
-    if resource_type == "Custom::LexBotAlias":
-        bot_id = helper_data.get("botId")
-        bot_alias_id = helper_data.get("botAliasId")
-        if bot_id and bot_alias_id:
-            LEX_CUSTOM_RESOURCE.wait_for_delete_bot_alias(bot_id=bot_id, bot_alias_id=bot_alias_id)
-        return True
-
-    raise RuntimeError(f"Invalid resource type: {resource_type}")
-
-
 @HELPER.delete
 def delete_resource(event, _):
     """Delete Resource"""
@@ -163,6 +136,7 @@ def delete_resource(event, _):
         if bot_id:
             try:
                 LEX_CUSTOM_RESOURCE.delete_bot(bot_id=bot_id)
+                LEX_CUSTOM_RESOURCE.wait_for_delete_bot(bot_id=bot_id)
             except CLIENT.exceptions.PreconditionFailedException:
                 LOGGER.info("Bot does not exist - bot_id: %s", bot_id)
 
@@ -183,6 +157,7 @@ def delete_resource(event, _):
         if bot_alias_id and bot_id:
             try:
                 LEX_CUSTOM_RESOURCE.delete_bot_alias(bot_id=bot_id, bot_alias_id=bot_alias_id)
+                LEX_CUSTOM_RESOURCE.wait_for_delete_bot_alias(bot_id=bot_id, bot_alias_id=bot_alias_id)
             except CLIENT.exceptions.PreconditionFailedException:
                 LOGGER.info(
                     "Bot alias does not exist - bot_id: %s - bot_alias_id: %s",


### PR DESCRIPTION
Hi there! We noticed an issue deleting Lex bot resources when using this custom resource due to the polling/async behaviour in the `crhelper` library.

I've tested the changes in the PR against our own larger bot definition and they seem to correctly delete the resource with the polling strategy removed.

*Issue #, if available:*

resolves: https://github.com/aws-samples/aws-lex-v2-cfn-cr/issues/1

*Description of changes:*

* There is an 8KB limit to `AWS::Events::Rule` resources that are
  created by the  `crhelper` library to implement a polling
  strategy for the custom resource.
* The polling strategies for `update` and `create` were previously
  removed in commit ad497cecf6a4ba5f29805f1553c5f6a70b758222, but
  the `poll_delete` function was not removed.
* For larger bot definitions (ie. > 8KB), the custom resource
  correctly creates and updates the bot resource, but it will
  fail on deletion with an error message of:

```
'targets.1.member.input' failed to satisfy constraint:

Member must have length less than or equal to 8192
```
* To resolve this issue, simply remove the `poll_delete` function
  and update the `delete_resource` function to wait for the bot
  and the bot alias to be fully deleted.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
