### PR TITLE
feat(alias): Add Support for TestBotAlias

### DIFF
--- a/examples/banker-bot/template.yaml
+++ b/examples/banker-bot/template.yaml
@@ -306,6 +306,35 @@ Resources:
       CR.botLocaleIds: !GetAtt LexBot.botLocaleIds
       CR.lastUpdatedDateTime: !GetAtt LexBot.lastUpdatedDateTime
 
+  # wire up our test bot alias for testing in the AWS console
+  LexBotTestAlias:
+    # Alias is deleted by the Bot on Stack Deletions
+    DeletionPolicy: Retain
+    Type: Custom::LexBotAlias
+    Properties:
+      ServiceToken:
+        !ImportValue
+          Fn::Sub: "${LexV2CfnCrStackName}-LexV2CfnCrFunctionArn"
+      botId: !Ref LexBot
+      botAliasName: TestBotAlias
+      botVersion: DRAFT
+      botAliasLocaleSettings:
+        en_US:
+          enabled: True
+          # Lambda Code Hook
+          codeHookSpecification:
+            lambdaCodeHook:
+              lambdaARN: !GetAtt LexBotFunction.Arn
+              codeHookInterfaceVersion: "1.0"
+      conversationLogSettings:
+        # Text Conversation Logs to CloudWatch
+        textLogSettings:
+          - enabled: True
+            destination:
+              cloudWatch:
+                cloudWatchLogGroupArn: !GetAtt LexBotConversationLogs.Arn
+                logPrefix: !Sub "aws/lex/${LexBot}/DRAFT/"
+
   LexBotAlias:
     # Alias is deleted by the Bot on Stack Deletions
     DeletionPolicy: Retain


### PR DESCRIPTION
Hi There!

It looks like commit 63bdce34d86d6a5bfb72ac93c45e33da2a834f35 added support for the default `FallbackIntent` that is automatically provisioned during bot creation.

The Lex V2 service has another similar scenario with regards to the `TestBotAlias`. This alias is used for manual testing in the AWS console and is also automatically provisioned during bot creation.

This PR adds support for defining and configuring the `TestBotAlias`.

*Issue #, if available:*

_N/A_

*Description of changes:*

* The Lex V2 service will automatically provision a `TestBotAlias`
  alias for manual testing when a new bot is created.
* Lex model building APIs won't allow clients to call the
  `create_bot_alias` action for a TestBotAlias - it can only
  be updated.
* The default TestBotAlias always has a static id of `TSTALIASID`.
* The TestBotAlias must always have a `botVersion` value of `DRAFT`.
* Intercept calls to `create_resource` for BotAlias resources and
  call `update_resource` if and only if the alias name is
  "TestBotAlias". This allows users to provision their test alias
  and associate it to a lambda function as well as configure
  sentiment/locales and conversation logs for the alias.
* Update the BankerBot example to include a resource for the
  TestBotAlias.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
